### PR TITLE
Central oidc logout

### DIFF
--- a/modules/portal/app/modules/SecurityModule.scala
+++ b/modules/portal/app/modules/SecurityModule.scala
@@ -71,6 +71,7 @@ class SecurityModule(environment: Environment, configuration: Configuration)
     val logoutController = new LogoutController()
     logoutController.setDefaultUrl("/")
     logoutController.setDestroySession(true)
+    logoutController.setCentralLogout(true)
     bind(classOf[LogoutController]).toInstance(logoutController)
 
     // security components used in controllers


### PR DESCRIPTION
forgot to include this, otherwise only the session is destroyed but the user would still be logged into the oidc provider once they bounce back 
